### PR TITLE
correct error type for aead_type_to_mode in evercrypt provider

### DIFF
--- a/evercrypt_provider/CHANGELOG.md
+++ b/evercrypt_provider/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- [#37](https://github.com/franziskuskiefer/hpke-rs/pull/37): correct error type for aead_type_to_mode
+
+## 0.1.2 (2022-02-24)
+
+* initial release
+
+*Please disregard any previous versions.*

--- a/evercrypt_provider/src/lib.rs
+++ b/evercrypt_provider/src/lib.rs
@@ -208,7 +208,7 @@ fn aead_type_to_mode(alg: AeadAlgorithm) -> Result<AeadMode, Error> {
         AeadAlgorithm::Aes128Gcm => Ok(AeadMode::Aes128Gcm),
         AeadAlgorithm::Aes256Gcm => Ok(AeadMode::Aes256Gcm),
         AeadAlgorithm::ChaCha20Poly1305 => Ok(AeadMode::Chacha20Poly1305),
-        _ => Err(Error::UnknownKemAlgorithm),
+        _ => Err(Error::UnknownAeadAlgorithm),
     }
 }
 


### PR DESCRIPTION
Hi, thanks for providing this library! It looks like the wrong error type was being returned by this helper function in the `evercrypt_provider` crate. I had some trouble getting `evercrypt-sys` to build on my M1 mac, so have only tested the fix on Ubuntu 18.04