### PR TITLE
lib: implement std::error::Error for HpkeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ evercrypt_provider/target
 rust_crypto_provider/target
 traits/target/
 .DS_Store
+/.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,14 @@ pub enum HpkeError {
     LockPoisoned,
 }
 
+impl std::error::Error for HpkeError {}
+
+impl std::fmt::Display for HpkeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HPKE Error: {:?}", self)
+    }
+}
+
 #[deprecated(
     since = "0.0.7",
     note = "Please use HpkePublicKey instead. This alias will be removed with the first stable  0.1 release."


### PR DESCRIPTION
This branch implements `std::error::Error`, and `std::fmt::Display` for `HpkeError`, matching the approach already used for
`hpke_rs_crypto::Error`. This makes handling `HpkeError` as a generic `Error` easier in downstream crates. Hopefully I haven't overlooked a reason you explicitly chose not to do this initially.