### PR TITLE
hpks-rs-crypto: simplify Cargo.toml

### DIFF
--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,7 +10,6 @@ readme = "Readme.md"
 repository = "https://github.com/franziskuskiefer/hpke-rs"
 
 [dependencies]
-serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 rand_core = { version = "0.6.4" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -13,4 +13,3 @@ repository = "https://github.com/franziskuskiefer/hpke-rs"
 serde = { version = "1.0", features = ["derive"] }
 rand_core = { version = "0.6.4" }
 getrandom = { version = "0.2", features = ["js"] }
-tls_codec = { version = "0.4.0", features = ["derive"] }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/franziskuskiefer/hpke-rs"
 [dependencies]
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
-rand = { version = "0.8" }
+rand_core = { version = "0.6.4" }
 getrandom = { version = "0.2", features = ["js"] }
 tls_codec = { version = "0.4.0", features = ["derive"] }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -7,13 +7,13 @@ pub mod error;
 pub mod types;
 
 // re-export trait
-pub use rand::{CryptoRng, RngCore};
+pub use rand_core::{CryptoRng, RngCore};
 
 /// The [`HpkeCrypto`] trait defines the necessary cryptographic functions used
 /// in the HPKE implementation.
 pub trait HpkeCrypto: core::fmt::Debug + Send + Sync {
     /// The PRNG implementation returned in [`HpkeCrypto::prng()`].
-    type HpkePrng: rand::RngCore + rand::CryptoRng + HpkeTestRng;
+    type HpkePrng: RngCore + CryptoRng + HpkeTestRng;
 
     /// The name of the implementation.
     fn name() -> String;
@@ -122,7 +122,7 @@ pub trait HpkeCrypto: core::fmt::Debug + Send + Sync {
 /// PRNG extension for testing that is supposed to return pre-configured bytes.
 pub trait HpkeTestRng {
     /// Like [`RngCore::try_fill_bytes`] but the result is expected to be known.
-    fn try_fill_test_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error>;
+    fn try_fill_test_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error>;
 
     /// Set the randomness state of this test PRNG.
     fn seed(&mut self, seed: &[u8]);


### PR DESCRIPTION
I was looking into adding no-std support to this family of crates and noticed the hpks-rs-crypto crate has a few unused dependencies and could directly use `rand_core`