### PR TITLE
hpke-rs-crypto: make serde opt-in

### DIFF
--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -10,6 +10,9 @@ readme = "Readme.md"
 repository = "https://github.com/franziskuskiefer/hpke-rs"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 rand_core = { version = "0.6.4" }
 getrandom = { version = "0.2", features = ["js"] }
+
+[features]
+serde = ["dep:serde"]

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -2,12 +2,14 @@
 //!
 //! Algorithm definitions for the [`crate::HpkeCrypto`] trait.
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::error;
 
 /// KEM Modes
-#[derive(PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(PartialEq, Copy, Clone, Debug)]
 #[repr(u16)]
 pub enum KemAlgorithm {
     /// DH KEM on P256
@@ -70,7 +72,8 @@ impl KemAlgorithm {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u16)]
 /// AEAD types
 pub enum AeadAlgorithm {
@@ -150,7 +153,8 @@ impl AeadAlgorithm {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u16)]
 /// KDF types
 /// Value are taken from the HPKE RFC (not published yet)


### PR DESCRIPTION
this puts the `Serialize` and `Deserialize` derives behind an opt-in Cargo feature called "serde". this is a *semver breaking change*. 