### PR TITLE
rm `RwLock` from `Hpke` and no-std-ify the `hpke-rs` library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ hpke-rs-crypto = { version = "0.1.3", path = "./traits" }
 
 [features]
 default = []
-serialization = ["serde", "serde_json", "tls_codec", "tls_codec/serde"]
+std = []
+serialization = ["serde", "serde_json", "tls_codec", "tls_codec/serde", "std"]
 hazmat = []
-hpke-test = []
+hpke-test = ["std"]
 hpke-test-prng = []                                                     # ⚠️ Enable testing PRNG - DO NOT USE
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/franziskuskiefer/hpke-rs"
 
 [dependencies]
 log = "0.4"
-serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 tls_codec = { version = "0.4.0", features = ["derive"], optional = true }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
@@ -20,7 +19,7 @@ hpke-rs-crypto = { version = "0.1.3", path = "./traits" }
 [features]
 default = []
 std = []
-serialization = ["serde", "serde_json", "tls_codec", "tls_codec/serde", "std"]
+serialization = ["serde", "tls_codec", "tls_codec/serde", "std"]
 hazmat = []
 hpke-test = ["std"]
 hpke-test-prng = []                                                     # ⚠️ Enable testing PRNG - DO NOT USE

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -49,7 +49,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                     if Crypto::supports_kem(kem_mode).is_err() {
                         continue;
                     }
-                    let hpke = Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
+                    let mut hpke = Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                     let label = format!("{} {}", Crypto::name(), hpke);
                     let kp = hpke.generate_key_pair().unwrap();
                     let enc = kp.public_key().as_slice();
@@ -83,7 +83,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                     let mut group = c.benchmark_group(format!("{}", label));
                     group.bench_function("Setup Sender", |b| {
                         b.iter(|| {
-                            let hpke =
+                            let mut hpke =
                                 Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                             hpke.setup_sender(
                                 &pk_rm,
@@ -114,7 +114,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                     group.bench_function(&format!("Seal {}({})", AEAD_PAYLOAD, AEAD_AAD), |b| {
                         b.iter_batched(
                             || {
-                                let hpke =
+                                let mut hpke =
                                     Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                                 let (_enc, context) = hpke
                                     .setup_sender(
@@ -140,7 +140,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                     group.bench_function(&format!("Open {}({})", AEAD_PAYLOAD, AEAD_AAD), |b| {
                         b.iter_batched(
                             || {
-                                let hpke =
+                                let mut hpke =
                                     Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                                 let (enc, mut sender_context) = hpke
                                     .setup_sender(
@@ -190,7 +190,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                                     OsRng.fill_bytes(&mut ptxt);
                                     (hpke, aad, ptxt)
                                 },
-                                |(hpke, aad, ptxt)| {
+                                |(mut hpke, aad, ptxt)| {
                                     let _ctxt = hpke
                                         .seal(
                                             &pk_rm,
@@ -212,7 +212,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>(c: &mut Criterion) {
                         |b| {
                             b.iter_batched(
                                 || {
-                                    let hpke = Hpke::<Crypto>::new(
+                                    let mut hpke = Hpke::<Crypto>::new(
                                         hpke_mode, kem_mode, kdf_mode, aead_mode,
                                     );
                                     let (enc, mut sender_context) = hpke

--- a/benches/manual_benches.rs
+++ b/benches/manual_benches.rs
@@ -56,7 +56,7 @@ fn benchmark<Crypto: HpkeCrypto + 'static>() {
                     if Crypto::supports_kem(kem_mode).is_err() {
                         continue;
                     }
-                    let hpke = Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
+                    let mut hpke = Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                     let label = format!(
                         "{} {} {} {} {}",
                         Crypto::name(),
@@ -98,7 +98,8 @@ fn benchmark<Crypto: HpkeCrypto + 'static>() {
 
                     let start = Instant::now();
                     for _ in 0..ITERATIONS {
-                        let hpke = Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
+                        let mut hpke =
+                            Hpke::<Crypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
                         let _sender = hpke
                             .setup_sender(
                                 &pk_rm,

--- a/fuzz/fuzz_targets/base.rs
+++ b/fuzz/fuzz_targets/base.rs
@@ -5,7 +5,7 @@ use hpke_rs::prelude::*;
 use hpke_rs_crypto::types::*;
 
 fuzz_target!(|data: &[u8]| {
-    let hpke = Hpke::<hpke_rs_rust_crypto::HpkeRustCrypto>::new(
+    let mut hpke = Hpke::<hpke_rs_rust_crypto::HpkeRustCrypto>::new(
         HpkeMode::Base,
         KemAlgorithm::DhKemP256,
         KdfAlgorithm::HkdfSha256,

--- a/src/dh_kem.rs
+++ b/src/dh_kem.rs
@@ -1,5 +1,7 @@
 //! DH KEM as described in §4.1. DH-Based KEM.
 
+use alloc::{string::ToString, vec::Vec};
+
 use hpke_rs_crypto::{error::Error, types::KemAlgorithm, HpkeCrypto};
 
 use crate::util::*;

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use hpke_rs_crypto::{error::Error, types::KdfAlgorithm, HpkeCrypto};
 
 use crate::util::concat;

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use hpke_rs_crypto::{error::Error, types::KemAlgorithm, HpkeCrypto};
 
 use crate::dh_kem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,16 @@
     unused_extern_crates,
     unused_qualifications
 )]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 #[cfg(feature = "hpke-test-prng")]
 use hpke_rs_crypto::HpkeTestRng;
@@ -885,6 +895,8 @@ impl tls_codec::Deserialize for &HpkePublicKey {
 /// Test util module. Should be moved really.
 #[cfg(feature = "hpke-test")]
 pub mod test_util {
+    use alloc::{format, string::String, vec, vec::Vec};
+
     use crate::HpkeError;
     use hpke_rs_crypto::{HpkeCrypto, HpkeTestRng};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 use alloc::{
     format,
@@ -89,6 +91,7 @@ pub enum HpkeError {
     InsufficientRandomness,
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for HpkeError {}
 
 impl core::fmt::Display for HpkeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,8 @@ pub enum HpkeError {
 
 impl std::error::Error for HpkeError {}
 
-impl std::fmt::Display for HpkeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for HpkeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "HPKE Error: {:?}", self)
     }
 }
@@ -154,8 +154,8 @@ pub enum Mode {
     AuthPsk = 0x03,
 }
 
-impl std::fmt::Display for Mode {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for Mode {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
@@ -197,8 +197,8 @@ pub struct Context<Crypto: 'static + HpkeCrypto> {
 }
 
 #[cfg(feature = "hazmat")]
-impl<Crypto: HpkeCrypto> std::fmt::Debug for Context<Crypto> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<Crypto: HpkeCrypto> core::fmt::Debug for Context<Crypto> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Context {{\n  key: {:?}\n  nonce: {:?}\n exporter_secret: {:?}\n seq no: {:?}\n}}",
@@ -208,8 +208,8 @@ impl<Crypto: HpkeCrypto> std::fmt::Debug for Context<Crypto> {
 }
 
 #[cfg(not(feature = "hazmat"))]
-impl<Crypto: HpkeCrypto> std::fmt::Debug for Context<Crypto> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<Crypto: HpkeCrypto> core::fmt::Debug for Context<Crypto> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "Context {{\n  key: {:?}\n  nonce: {:?}\n exporter_secret: {:?}\n seq no: {:?}\n}}",
@@ -341,8 +341,8 @@ impl<Crypto: 'static + HpkeCrypto> Clone for Hpke<Crypto> {
     }
 }
 
-impl<Crypto: HpkeCrypto> std::fmt::Display for Hpke<Crypto> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl<Crypto: HpkeCrypto> core::fmt::Display for Hpke<Crypto> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             "{}_{}_{}_{}",
@@ -788,8 +788,8 @@ impl PartialEq for HpkePrivateKey {
 }
 
 #[cfg(not(feature = "hazmat"))]
-impl std::fmt::Debug for HpkePrivateKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Debug for HpkePrivateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("HpkePrivateKey")
             .field("value", &"***")
             .finish()
@@ -797,8 +797,8 @@ impl std::fmt::Debug for HpkePrivateKey {
 }
 
 #[cfg(feature = "hazmat")]
-impl std::fmt::Debug for HpkePrivateKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl core::fmt::Debug for HpkePrivateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
         f.debug_struct("HpkePrivateKey")
             .field("value", &self.value)
             .finish()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,4 +2,4 @@
 //! Include this to get access to all the public functions of HPKE.
 
 pub use super::{Mode as HpkeMode, *};
-pub use std::convert::TryFrom;
+pub use core::convert::TryFrom;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 #[inline]
 pub(crate) fn concat(values: &[&[u8]]) -> Vec<u8> {
     values.join(&[][..])

--- a/tests/test_hpke.rs
+++ b/tests/test_hpke.rs
@@ -43,7 +43,7 @@ macro_rules! generate_test_case {
     ($name:ident, $hpke_mode:expr, $kem_mode:expr, $kdf_mode:expr, $aead_mode:expr, $provider:ident) => {
         #[test]
         fn $name() {
-            let hpke = Hpke::<$provider>::new($hpke_mode, $kem_mode, $kdf_mode, $aead_mode);
+            let mut hpke = Hpke::<$provider>::new($hpke_mode, $kem_mode, $kdf_mode, $aead_mode);
             println!("Self test {}", hpke);
 
             // Self test seal and open with random keys.

--- a/tests/test_hpke_kat.rs
+++ b/tests/test_hpke_kat.rs
@@ -181,7 +181,7 @@ fn kat<Crypto: HpkeCrypto + 'static>(tests: Vec<HpkeTestVector>) {
         #[cfg(feature = "hpke-test-prng")]
         {
             log::trace!("Testing with known ikmE ...");
-            let hpke_sender = Hpke::<Crypto>::new(mode, kem_id, kdf_id, aead_id);
+            let mut hpke_sender = Hpke::<Crypto>::new(mode, kem_id, kdf_id, aead_id);
             // This only works when seeding the PRNG with ikmE.
             hpke_sender.seed(&ikm_e).expect("Error injecting ikm_e");
             let (enc, _sender_context_kat) = hpke_sender
@@ -298,7 +298,7 @@ fn test_serialization() {
                 for &kem_mode in &[0x10u16, 0x20] {
                     let kem_mode = KemAlgorithm::try_from(kem_mode).unwrap();
 
-                    let hpke =
+                    let mut hpke =
                         Hpke::<HpkeRustCrypto>::new(hpke_mode, kem_mode, kdf_mode, aead_mode);
 
                     // JSON: Public, Private, KeyPair


### PR DESCRIPTION
implements #52 

this adds an *opt-out* Cargo feature named "std" and changes the signature of `Hpke`'s methods; thus it's a *semver breaking change*.

this PR is best reviewed on a commit by commit basis

due to #54 I'm unable to test running this on a no-std target like the `thumbv7em-none-eabihf` but AFAICT no other dependency is pulling in libstd