### PR TITLE
CI: check no-std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,3 +108,18 @@ jobs:
           version: latest
       - name: Fuzz Base w/ RustCrypto
         run: cargo fuzz run base -- -runs=10000
+
+  no-std-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # we use a target that lacks a pre-compiled libstd to check if any dependency is using libstd
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          default: true
+      - name: build crates in no-std mode
+        run: cargo check --target thumbv7em-none-eabihf
+        working-directory: no-std-support-check

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Cargo.lock
 **/*.rs.bk
 .vscode/
 evercrypt_provider/target
+no-std-support-check/target
 rust_crypto_provider/target
 traits/target/
 .DS_Store

--- a/no-std-support-check/Cargo.toml
+++ b/no-std-support-check/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+name = "no-std-support-check"
+publish = false
+version = "0.0.0"
+
+[dependencies]
+hpke-rs = { path = ".." }
+hpke-rs-crypto = { path = "../traits" }
+hpke-rs-rust-crypto = { path = "../rust_crypto_provider" }
+
+# the no-std-support-check CI job uses the `thumbv7em-none-eabihf` target
+# `getrandom` does not support that target out of box so this feature needs to be enabled to avoid a compilation error
+# (normally this feature should NOT be enabled in a library but this crate is just used for a CI check)
+getrandom = { version = "0.2.11", features = ["custom"] }

--- a/no-std-support-check/src/lib.rs
+++ b/no-std-support-check/src/lib.rs
@@ -1,0 +1,3 @@
+//! used in CI to check that crates are no-std compatible
+
+#![no_std]


### PR DESCRIPTION
for the time being, this only checks that the `hpke-rs-crypto` crate is no-std compatible.

this new CI job won't pass until #50 is merged