### PR TITLE
hpke-rs-rust-crypto: make deterministic-prng enable the std feature

### DIFF
--- a/rust_crypto_provider/Cargo.toml
+++ b/rust_crypto_provider/Cargo.toml
@@ -28,7 +28,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 rand = { version = "0.8" }
 
 [features]
-deterministic-prng = [] # ⚠️ FOR TESTING ONLY.
+deterministic-prng = ["hpke-rs-crypto/std"] # ⚠️ FOR TESTING ONLY.
 
 [[bench]]
 name = "bench_hkdf"


### PR DESCRIPTION
I noticed that running `cargo build --all-features` from the `rust_crypto_provider` directory does not work unless the `std` feature of its `hpke-rs-crypto` dependency is enabled so this PR fixes that

this is not a problem when running `cargo test` from the root of the repo because `hpke-rs` enables both `hpke-rs-rust-crypto/deterministic-prng` and `hpke-rs-crypto`. would it be worthwhile to run `cargo b --all-features` from the `rust_crypto_provider` directory in CI?