### PR TITLE
[CI] Update code coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
+          components: rustc, rust-std, cargo, llvm-tools, llvm-tools-preview
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: grcov


### PR DESCRIPTION
This PR updates the `coverage.yml` workflow in CI to replace `-Zprofile` (which is no longer available) with `-Cinstrument-coverage` and the options it needs for doctests. It also replaces `actions-rs/grcov` with `grcov` installed via cargo.
