### PR TITLE
Nonce reuse vulnerability in hpke-rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,10 @@ impl<Crypto: HpkeCrypto> Context<Crypto> {
         {
             return Err(HpkeError::MessageLimitReached);
         }
-        self.sequence_number += 1;
+        self.sequence_number = self
+            .sequence_number
+            .checked_add(1)
+            .ok_or(HpkeError::MessageLimitReached)?;
         Ok(())
     }
 }


### PR DESCRIPTION
A critical nonce reuse vulnerability was discovered in the hpke-rs library that affects release builds only. The vulnerability allows an attacker to potentially recover plaintexts when a single HPKE context encrypts more than 2^32 messages.

The HPKE context maintains a sequence_number field used to derive unique nonces for each encryption operation:

```rust
pub struct Context<Crypto: 'static + HpkeCrypto> {
    key: Vec<u8>,
    nonce: Vec<u8>,
    exporter_secret: Vec<u8>,
    sequence_number: u32,
    hpke: Hpke<Crypto>,
}
```

The `increment_seq()` function checks if the sequence number has exceeded the RFC-mandated limit before incrementing:

```rust
fn increment_seq(&mut self) -> Result<(), HpkeError> {
    if u128::from(self.sequence_number)
        >= ((1u128 << (8 * Crypto::aead_nonce_length(self.hpke.aead_id))) - 1)
    {
        return Err(HpkeError::MessageLimitReached);
    }
    self.sequence_number += 1;
    Ok(())
}
```

In [Section 5.2, RFC 9180](https://www.rfc-editor.org/rfc/rfc9180.html#name-encryption-and-decryption) specifies that the sequence number limit should be `2^(8*Nn) - 1`, where Nn is the nonce length in bytes. For standard AEADs like AES-GCM and ChaCha20-Poly1305, the nonce length is 12 bytes, making the limit `2^96 - 1`.

However, the sequence_number is stored as a u32, which has a maximum value of 2^32 - 1. This creates two problems:

1. The overflow check (comparing against 2^96 - 1) will NEVER trigger because a u32 can never be >= 2^96 - 1.

2. When sequence_number reaches u32::MAX and is incremented:
   - In DEBUG builds: Rust panics due to overflow checking (fails safely).
   - In RELEASE builds: **The value silently wraps to 0, hence creating a nonce reuse vulnerability**.

Any application using hpke-rs that:

1. Uses a single HPKE context for a very large number of encryptions,
2. Runs in release mode (standard for production),
3. Encrypts more than 2^32 (~4.3 billion) messages with the same context...

...will experience nonce reuse, leading to trivial message decryption.

Nonce reuse with AEAD ciphers is catastrophic:

- For AES-GCM: Nonce reuse leaks the authentication key (GHASH key H), allowing forgeries. XORing two ciphertexts reveals XOR of plaintexts.

- For ChaCha20-Poly1305: XORing two ciphertexts encrypted with the same nonce reveals the XOR of the plaintexts, enabling plaintext recovery attacks.

The fix uses Rust's `checked_add()` method to detect overflow before it occurs:

```rust
fn increment_seq(&mut self) -> Result<(), HpkeError> {
    // Keep the RFC-specified limit check (for AEADs with smaller nonces)
    if u128::from(self.sequence_number)
        >= ((1u128 << (8 * Crypto::aead_nonce_length(self.hpke.aead_id))) - 1)
    {
        return Err(HpkeError::MessageLimitReached);
    }
    // Use checked_add to prevent silent wraparound in release builds
    self.sequence_number = self
        .sequence_number
        .checked_add(1)
        .ok_or(HpkeError::MessageLimitReached)?;
    Ok(())
}
```

--- 
[Music that inspired this work](https://www.youtube.com/watch?v=Vd9VFloRPUk)