### PR TITLE
bump rand crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,10 @@ rustcrypto = ["dep:hpke-rs-rust-crypto"]
 libcrux = ["dep:hpke-rs-libcrux"]
 
 hpke-test = ["std"]
-hpke-test-prng = [] # ⚠️ Enable testing PRNG - DO NOT USE
+hpke-test-prng = [
+    "hpke-rs-rust-crypto?/deterministic-prng",
+    "hpke-rs-libcrux?/deterministic-prng",
+] # ⚠️ Enable testing PRNG - DO NOT USE
 
 [dev-dependencies]
 hpke-rs-crypto = { version = "0.4.0", path = "./traits", features = ["std"] }
@@ -47,13 +50,9 @@ serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4"
 rayon = "1.5"
 hpke-rs = { path = ".", features = ["hpke-test", "hazmat"] }
-hpke-rs-rust-crypto = { version = "0.4.0", path = "./rust_crypto_provider", features = [
-    "deterministic-prng",
-] }
-hpke-rs-libcrux = { version = "0.5.1", path = "./libcrux_provider", features = [
-    "deterministic-prng",
-] }
-rand = { version = "0.9" }
+hpke-rs-rust-crypto = { version = "0.4.0", path = "./rust_crypto_provider" }
+hpke-rs-libcrux = { version = "0.5.1", path = "./libcrux_provider" }
+rand = { version = "0.10" }
 pretty_env_logger = "0.5"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,10 +2,11 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use hpke_rs::{prelude::*, test_util::hex_to_bytes};
 use hpke_rs_crypto::{
     types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
-    HpkeCrypto, RngCore,
+    HpkeCrypto,
 };
 use hpke_rs_libcrux::HpkeLibcrux;
 use hpke_rs_rust_crypto::*;
+use rand::Rng;
 
 const MODES: [Mode; 4] = [
     HpkeMode::Base,

--- a/benches/manual_benches.rs
+++ b/benches/manual_benches.rs
@@ -3,10 +3,11 @@ use std::time::{Duration, Instant};
 use hpke_rs::{prelude::*, test_util::hex_to_bytes};
 use hpke_rs_crypto::{
     types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm},
-    HpkeCrypto, RngCore,
+    HpkeCrypto,
 };
 use hpke_rs_libcrux::HpkeLibcrux;
 use hpke_rs_rust_crypto::*;
+use rand::Rng;
 
 fn duration(d: Duration) -> f64 {
     ((d.as_secs() as f64) + (d.subsec_nanos() as f64 * 1e-9)) * 1000000f64

--- a/libcrux_provider/Cargo.toml
+++ b/libcrux_provider/Cargo.toml
@@ -17,9 +17,9 @@ libcrux-kem = { version = "0.0.5", default-features = false }
 libcrux-aead = { version = "0.0.5" }
 libcrux-traits = { version = "0.0.5", default-features = false }
 # Randomness
-rand = { version = "0.9", default-features = false }
-rand_core = { version = "0.9", features = ["os_rng"] }
-rand_chacha = { version = "0.9", default-features = false }
+rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
+rand_core = { version = "0.10" }
+rand_chacha = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }


### PR DESCRIPTION
replaces #121 and #120 

Note that this disables the test rng by default on tests. We should run more versions on ci.