### PR TITLE
rc provider: check x25519 0 keys

### DIFF
--- a/rust_crypto_provider/src/lib.rs
+++ b/rust_crypto_provider/src/lib.rs
@@ -99,7 +99,7 @@ impl HpkeCrypto for HpkeRustCrypto {
                 }
 
                 if all_zero(&shared_secret) {
-                    return Err(Error::KemInvalidSecretKey);
+                    return Err(Error::KemInvalidPublicKey);
                 }
                 Ok(shared_secret)
             }


### PR DESCRIPTION
It's unclear whether Dalek performs the necessary check for 0 outputs on x25519. We there check again in the provider.

This issue was first [reported](https://github.com/cryspen/hpke-rs/pull/117) by Nadim Kobeissi.