### PR TITLE
feat: add gated ml-kem support to libcrux provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ hazmat = []
 rustcrypto = ["dep:hpke-rs-rust-crypto"]
 libcrux = ["dep:hpke-rs-libcrux"]
 experimental = ["hpke-rs-rust-crypto?/experimental"]
+draft-connolly-cfrg-hpke-mlkem = ["hpke-rs-libcrux?/draft-connolly-cfrg-hpke-mlkem"]
 
 hpke-test = ["std"]
 hpke-test-prng = [

--- a/libcrux_provider/Cargo.toml
+++ b/libcrux_provider/Cargo.toml
@@ -27,6 +27,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 
 [features]
 deterministic-prng = [] # ⚠️ FOR TESTING ONLY.
+draft-connolly-cfrg-hpke-mlkem = []
 std = [
     "rand/std",
     "rand_chacha/std",

--- a/libcrux_provider/src/lib.rs
+++ b/libcrux_provider/src/lib.rs
@@ -84,8 +84,16 @@ impl HpkeCrypto for HpkeLibcrux {
         prng: &mut Self::HpkePrng,
     ) -> Result<(Vec<u8>, Vec<u8>), Error> {
         match alg {
+            #[cfg(feature = "draft-connolly-cfrg-hpke-mlkem")]
+            KemAlgorithm::MlKem768 | KemAlgorithm::MlKem1024 => {
+                let kem_alg = kem_key_type_to_libcrux_alg(alg)?;
+                libcrux_kem::key_gen(kem_alg, prng)
+                    .map(|(sk, pk)| (pk.encode(), sk.encode()))
+                    .map_err(|e| Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e)))
+            }
             KemAlgorithm::XWingDraft06 => {
-                libcrux_kem::key_gen(libcrux_kem::Algorithm::XWingKemDraft06, prng)
+                let kem_alg = kem_key_type_to_libcrux_alg(alg)?;
+                libcrux_kem::key_gen(kem_alg, prng)
                     .map(|(sk, pk)| (pk.encode(), sk.encode()))
                     .map_err(|e| Error::CryptoLibraryError(format!("KEM key gen error: {:?}", e)))
             }
@@ -249,7 +257,13 @@ impl HpkeCrypto for HpkeLibcrux {
     /// Returns an error if the KEM algorithm is not supported by this crypto provider.
     fn supports_kem(alg: KemAlgorithm) -> Result<(), Error> {
         match alg {
-            KemAlgorithm::DhKem25519 | KemAlgorithm::DhKemP256 | KemAlgorithm::XWingDraft06 => {
+            KemAlgorithm::DhKem25519
+            | KemAlgorithm::DhKemP256
+            | KemAlgorithm::XWingDraft06 => {
+                Ok(())
+            }
+            #[cfg(feature = "draft-connolly-cfrg-hpke-mlkem")]
+            KemAlgorithm::MlKem768 | KemAlgorithm::MlKem1024 => {
                 Ok(())
             }
             _ => Err(Error::UnknownKemAlgorithm),
@@ -302,6 +316,10 @@ fn kem_key_type_to_libcrux_alg(alg: KemAlgorithm) -> Result<libcrux_kem::Algorit
     match alg {
         KemAlgorithm::DhKem25519 => Ok(libcrux_kem::Algorithm::X25519),
         KemAlgorithm::DhKemP256 => Ok(libcrux_kem::Algorithm::Secp256r1),
+        #[cfg(feature = "draft-connolly-cfrg-hpke-mlkem")]
+        KemAlgorithm::MlKem768 => Ok(libcrux_kem::Algorithm::MlKem768),
+        #[cfg(feature = "draft-connolly-cfrg-hpke-mlkem")]
+        KemAlgorithm::MlKem1024 => Ok(libcrux_kem::Algorithm::MlKem1024),
         KemAlgorithm::XWingDraft06 => Ok(libcrux_kem::Algorithm::XWingKemDraft06),
         _ => Err(Error::UnknownKemAlgorithm),
     }

--- a/tests/test_hpke.rs
+++ b/tests/test_hpke.rs
@@ -526,6 +526,173 @@ generate_test_case!(
     HpkeLibcrux
 );
 
+#[cfg(feature = "draft-connolly-cfrg-hpke-mlkem")]
+mod mlkem_libcrux {
+    use super::*;
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha256_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha384_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha384_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha512_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha512_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem768_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem768,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha256_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha256,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha384_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha384_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha384_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha384,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha512_chacha20poly1305_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::ChaCha20Poly1305,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha512_Aes128Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes128Gcm,
+        HpkeLibcrux
+    );
+
+    generate_test_case!(
+        base_mlkem1024_hkdfsha512_Aes256Gcm_libcrux,
+        HpkeMode::Base,
+        KemAlgorithm::MlKem1024,
+        KdfAlgorithm::HkdfSha512,
+        AeadAlgorithm::Aes256Gcm,
+        HpkeLibcrux
+    );
+}
+
 // XXX: These are broken and pre-releases. Disabling them until they are stable.
 #[cfg(feature = "experimental")]
 mod pq_kems {

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- [#146](https://github.com/cryspen/hpke-rs/pull/146): Add support for ML-KEM768 and ML-KEM1024 gated behind the `draft-connolly-cfrg-hpke-mlkem` feature flag.
+
 ## [0.4.0] - 2025-12-16
 
 - [#103](https://github.com/cryspen/hpke-rs/pull/103): Add correct code point for `XWingDraft06` ciphersuite and move old code point to `XWingDraft06Hpke`.


### PR DESCRIPTION
This PR adds support for ML-KEM768 and ML-KEM1024 to the libcrux provider gated behind a feature flag.